### PR TITLE
Use friso prefix for --with-friso

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Install libgroonga-dev, friso in the advance.
 
 Build this tokenizer.
 
-    % ./configure --with-friso=PATH_TO_LIB_DIR --with-friso-ini=PATH_TO_INI_FILE
+    % ./configure --with-friso=PATH_TO_FRISO_DIR --with-friso-ini=PATH_TO_INI_FILE
     % make
     % sudo make install
+
+Friso is installed into `/usr/lib` and `/usr/include/friso` by default. In this case, you should specify `--with-friso=/usr` option.
 
 ## Usage
 

--- a/configure.ac
+++ b/configure.ac
@@ -33,15 +33,13 @@ fi
 
 AC_ARG_WITH(friso,
             [AS_HELP_STRING([--with-friso=PATH],
-            [specify path to friso library directory.])],
-            [friso_libdir="$withval"],
-            [friso_libdir=""])
-if test "x$friso_libdir" != "x"; then
-   friso_include=`echo $friso_libdir | sed -e 's/\(.\+\)\/lib\/\?/\1/'`
-   FRISO_CFLAGS="-I$friso_include/include"
-   FRISO_LIBS="-lfriso"
-   FRISO_LDFLAGS="-L$friso_libdir ${FRISO_LIBS}"
-fi
+            [specify path to friso directory. (default=/usr)])],
+            [friso_dir="$withval"],
+            [friso_dir="/usr"])
+FRISO_CFLAGS="-I$friso_dir/include"
+FRISO_LIBS="-lfriso"
+FRISO_LDFLAGS="-L$friso_dir/lib ${FRISO_LIBS}"
+
 AC_SUBST(FRISO_CFLAGS)
 AC_SUBST(FRISO_LIBS)
 AC_SUBST(FRISO_LDFLAGS)


### PR DESCRIPTION
Because groonga-tokenizer-friso requires both Friso's lib dir and
include dir. It is better that we receive prefix of them and generates
lib dir and include dir from the prefix rather than guessing include
dir from lib dir.

Or we should receive both lib dir and include dir by options like
`--with-friso-lib-dir` and `--with-friso-include-dir`.
