### PR TITLE
More user friendly configuration error message

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,7 @@ AC_ARG_WITH(friso-ini,
 if test "x$friso_ini" != "x"; then
    FRISO_INI_PATH="$friso_ini"
 else
-   AC_ERROR("")
+   AC_ERROR("Could not find friso.ini. Please specify friso.ini PATH with '--with-friso-ini=PATH'")
 fi
 AC_DEFINE_UNQUOTED([FRISO_INI_PATH], ["$friso_ini"], ["Friso ini file"])
 


### PR DESCRIPTION
If it cannot find `friso.ini` in configure process, it makes configuration error.
Default error message can not be said that there is sufficient information to resolve configuration error.

Before:

``` log
configure: error: ""
```

After:

``` log
configure: error: "Could not find friso.ini. Please specify friso.ini PATH with '--with-friso-ini=PATH'"
```
